### PR TITLE
ci: fix release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,27 +81,27 @@ jobs:
 
       # Do a dry run of PSR
       - name: Test release
-        uses: relekang/python-semantic-release@v8.0.8
+        uses: python-semantic-release/python-semantic-release@v8.0.8
         if: github.ref_name != 'main'
         with:
           root_options: --noop
 
       # On main branch: actual PSR + upload to PyPI & GitHub
       - name: Release
-        uses: relekang/python-semantic-release@v8.0.8
-        id: release
+        id: semantic_release
+        uses: python-semantic-release/python-semantic-release@v8.0.8
         if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: steps.release.outputs.released == 'true'
+        if: steps.semantic_release.outputs.released == 'true'
         with:
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish package distributions to GitHub Releases
         uses: python-semantic-release/upload-to-gh-release@main
-        if: steps.release.outputs.released == 'true'
+        if: steps.semantic_release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Deleted
> - relekang/python-semantic-release@v8.0.8
> - id: release
> Added
> - python-semantic-release@v8.0.8
> - id: semantic_release
> #### Testing
> Run the CI workflow and verify that the release and distribution steps are executed correctly.
> #### Reasoning
> Updated the Python Semantic Release action to the official repository and renamed the step ID since it was causing the step to not appear in the workflow job.
</details>