### PR TITLE
ci: fix sync labels job

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   labels:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
The default CI token doesn't have permissions to manage labels, in order to do so we need to specify the write permission labels.
