### PR TITLE
fix: downgrade httpx minimal requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -941,4 +941,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a5ef031c52b460214849040fe68af13098077b45adbd43691b290ec142150af5"
+content-hash = "cf4115f9a63b1499de889ada45737cbba905df46b2a14c79f83343a2d153820c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-httpx = "^0.25.0"
+httpx = ">=0.24.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0"


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Updated
> - httpx
> #### Testing
> Run the tests and verify that they pass. Also, test the functionality that depends on the httpx library.
> #### Reasoning
> This library is used in homeassistant and httpx library is a dependency in both modules. Reduced the minimal requirements to prevent issues with dependency hell
</details>